### PR TITLE
Fix Umami analytics script URL

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
 
       <Script
         async
-        src="https://analytics.us.umami.is/script.js"
+        src="https://cloud.umami.is/script.js"
         data-website-id={process.env.UMAMI_ID}
       />
     </html>


### PR DESCRIPTION
## Summary
- Switch the Umami tracking script from `https://analytics.us.umami.is/script.js` to `https://cloud.umami.is/script.js`
- The US regional endpoint is a separate backend; website IDs from the main Umami Cloud dashboard only receive events from the default cloud script

## Test plan
- [x] Verified locally: old URL failed in DevTools Network panel, new URL returns 200
- [ ] After deploy, confirm pageviews appear in the Umami dashboard


Made with [Cursor](https://cursor.com)